### PR TITLE
Update selectByVisibleText.js

### DIFF
--- a/lib/commands/selectByVisibleText.js
+++ b/lib/commands/selectByVisibleText.js
@@ -54,7 +54,7 @@ let selectByVisibleText = function (selector, text) {
             formatted = 'concat("' + text.trim().split('"').join('", \'"\', "') + '")' // escape quotes
         }
 
-        var normalized = `[normalize-space(.) = ${formatted}]`
+        var normalized = `[normalize-space(translate(., ' ', '')) = ${formatted}]`
         return this.elementIdElement(res.value.ELEMENT, `./option${normalized}|./optgroup/option${normalized}`)
     }).then((res) => {
         /**


### PR DESCRIPTION
Fixing selectByVisibleText in case &nbsp; (which was inserted by Alt + 0160) cannot be removed by normalize-space

## Proposed changes
Currently, selectByVisibleText doesn't work with the following case (non-breaking leading space ):
`<select name="list_max">`
`<option value="15">&nbsp;15</option>`
`</select>`

I made a little change in xpath of option to remove &nbsp; (by translating (Alt + 0160) to '')
`normalize-space(.)` => `normalize-space(translate(., ' ', '')`

Issue: [XPath doesn't detect text with & nbsp; as spaces](https://groups.google.com/forum/#!topic/selenium-users/BO6dtIXr8Nk)

## Types of changes
- [`x`] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
- [ x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

### Reviewers: @christian-bromann
